### PR TITLE
Add extended ElasticSearch 7+ support and more flexibility to `elastic` lib

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -23,6 +23,7 @@
     "port": 9200,
     "protocol": "http",
     "requestTimeout": 5000,
+    "pingTimeout": 1000,
     "min_score": 0.01,
     "indices": [
       "vue_storefront_catalog",
@@ -386,7 +387,7 @@
       },
       "product": {
         "excludeFields": [ "updated_at", "created_at", "attribute_set_id", "status", "visibility", "tier_prices", "options_container", "msrp_display_actual_price_type", "has_options", "stock.manage_stock", "stock.use_config_min_qty", "stock.use_config_notify_stock_qty", "stock.stock_id",  "stock.use_config_backorders", "stock.use_config_enable_qty_inc", "stock.enable_qty_increments", "stock.use_config_manage_stock", "stock.use_config_min_sale_qty", "stock.notify_stock_qty", "stock.use_config_max_sale_qty", "stock.use_config_max_sale_qty", "stock.qty_increments", "small_image"],
-        "includeFields": null,
+        "includeFields": [],
         "filterFieldMapping": {
           "category.name": "category.name.keyword"
         }

--- a/packages/default-catalog/api/attribute/service.ts
+++ b/packages/default-catalog/api/attribute/service.ts
@@ -62,7 +62,8 @@ async function setAttributeInCache (attributeList, indexName: string, config: IC
       await Promise.all(
         attributeList.map(attribute => cache.set(
           `api:attribute-list:${indexName}:${attribute.attribute_code}`,
-          attribute
+          attribute,
+          []
         ))
       )
     } catch (err) {

--- a/packages/default-catalog/api/attribute/service.ts
+++ b/packages/default-catalog/api/attribute/service.ts
@@ -16,7 +16,7 @@ export interface AttributeListParam {
  */
 function transformAggsToAttributeListParam (aggregations: Record<string, any>): AttributeListParam {
   const attributeListParam: AttributeListParam = Object.keys(aggregations)
-    .filter(key => aggregations[key].buckets.length) // leave only buckets with values
+    .filter(key => aggregations[key].buckets && aggregations[key].buckets.length)
     .reduce((acc, key) => {
       const attributeCode = key.replace(/^(agg_terms_|agg_range_)|(_options)$/g, '')
       const bucketsIds = aggregations[key].buckets.map(bucket => bucket.key)

--- a/packages/default-catalog/api/attribute/service.ts
+++ b/packages/default-catalog/api/attribute/service.ts
@@ -159,7 +159,7 @@ function transformToMetadata ({
   attribute_code,
   slug,
   options = []
-}): Record<string, any> {
+}): any {
   return {
     is_visible_on_front,
     is_visible,

--- a/packages/default-catalog/api/attribute/service.ts
+++ b/packages/default-catalog/api/attribute/service.ts
@@ -116,7 +116,6 @@ async function list (attributesParam: AttributeListParam, config, indexName: str
   try {
     const query = adjustQuery({
       index: indexName,
-      type: 'attribute',
       body: bodybuilder().filter('terms', 'attribute_code', attributeCodes).build()
     }, 'attribute', config)
     const response = await getElasticClient(config).search(query)

--- a/packages/default-catalog/api/attribute/service.ts
+++ b/packages/default-catalog/api/attribute/service.ts
@@ -42,7 +42,6 @@ async function getAttributeFromCache (attributeCode: string, indexName: string, 
   if (config.server.useOutputCache && cache) {
     try {
       const res = await cache.get(
-        'api:attribute-list' + attributeCode,
         `api:attribute-list:${indexName}:${attributeCode}`
       )
       return res
@@ -77,7 +76,7 @@ async function setAttributeInCache (attributeList, indexName: string, config: IC
  * @param attribute - attribute object
  * @param optionsIds - list of only needed options ids
  */
-function clearAttributeOpitons (attribute, optionsIds: number[]) {
+function clearAttributeOptions (attribute, optionsIds: number[]) {
   const stringOptionsIds = optionsIds.map(String)
   return {
     ...attribute,
@@ -103,7 +102,7 @@ async function list (attributesParam: AttributeListParam, config: IConfig, index
         attributeCodes.splice(index, 1)
 
         // clear unused options
-        return clearAttributeOpitons(cachedAttribute, attributeOptionsIds)
+        return clearAttributeOptions(cachedAttribute, attributeOptionsIds)
       }
     })
     // remove empty results from cache.get
@@ -134,7 +133,7 @@ async function list (attributesParam: AttributeListParam, config: IConfig, index
         const attributeOptionsIds = attributesParam[fetchedAttribute.attribute_code]
 
         // clear unused options
-        return clearAttributeOpitons(fetchedAttribute, attributeOptionsIds)
+        return clearAttributeOptions(fetchedAttribute, attributeOptionsIds)
       })
     ]
 

--- a/packages/default-catalog/api/catalog.ts
+++ b/packages/default-catalog/api/catalog.ts
@@ -1,36 +1,38 @@
-import jwt from 'jwt-simple';
-import request from 'request';
-import ProcessorFactory from '../processor/factory';
-import { adjustBackendProxyUrl } from '@storefront-api/lib/elastic'
-import cache from '@storefront-api/lib/cache-instance'
-import { sha3_224 } from 'js-sha3'
-import Logger from '@storefront-api/lib/logger'
-import bodybuilder from 'bodybuilder'
-import { elasticsearch, SearchQuery } from 'storefront-query-builder'
-import AttributeService from './attribute/service'
-import loadCustomFilters from '../helper/loadCustomFilters'
+import { getClient as esClient, adjustQuery, adjustQueryParams, getTotals } from '@storefront-api/lib/elastic'
+import { elasticsearch, SearchQuery, ElasticsearchQueryConfig } from 'storefront-query-builder'
 import { apiError } from '@storefront-api/lib/util'
+import { Router, Request, Response } from 'express'
+import { ExtensionAPIFunctionParameter } from '@storefront-api/lib/module'
+import cache from '@storefront-api/lib/cache-instance'
+import AttributeService from './attribute/service'
+import ProcessorFactory from '../processor/factory'
+import loadCustomFilters from '../helper/loadCustomFilters'
+import { sha3_224 } from 'js-sha3'
 
-function _cacheStorageHandler (config, result, hash, tags) {
-  if (config.server.useOutputCache && cache) {
-    cache.set(
+import { IConfig } from 'config'
+import bodybuilder from 'bodybuilder'
+import jwt from 'jwt-simple'
+
+async function _cacheStorageHandler (config: IConfig, result: Record<string, any>, hash: string, tags = []): Promise<void> {
+  if (config.get<boolean>('server.useOutputCache') && cache) {
+    return cache.set(
       'api:' + hash,
       result,
       tags
     ).catch((err) => {
-      Logger.error(err)
+      console.error(err)
     })
   }
 }
 
-function _outputFormatter (responseBody, format = 'standard') {
+function _outputFormatter (responseBody: Record<string, any>, format = 'standard'): Record<string, any> {
   if (format === 'compact') { // simple formatter
     delete responseBody.took
     delete responseBody.timed_out
     delete responseBody._shards
     if (responseBody.hits) {
       delete responseBody.hits.max_score
-      responseBody.total = responseBody.hits.total
+      responseBody.total = getTotals(responseBody)
       responseBody.hits = responseBody.hits.hits.map(hit => {
         return Object.assign(hit._source, { _score: hit._score })
       })
@@ -39,39 +41,43 @@ function _outputFormatter (responseBody, format = 'standard') {
   return responseBody
 }
 
-export default ({ config, db }) => async function (req, res, body) {
+export default ({ config }: ExtensionAPIFunctionParameter) => async function (req: Request, res: Response): Promise<void | Router> {
   let groupId = null
 
   // Request method handling: exit if not GET or POST
-  // Other metods - like PUT, DELETE etc. should be available only for authorized users or not available at all)
+  // Other methods - like PUT, DELETE etc. should be available only for authorized users or not available at all)
   if (!(req.method === 'GET' || req.method === 'POST' || req.method === 'OPTIONS')) {
     throw new Error('ERROR: ' + req.method + ' request method is not supported.')
   }
 
-  let requestBody: Record<string, any> = req.body as Record<string, any>
   let responseFormat = 'standard'
+  let requestBody = req.body
   if (req.method === 'GET') {
     if (req.query.request) { // this is in fact optional
-      requestBody = JSON.parse(decodeURIComponent(req.query.request))
+      try {
+        requestBody = JSON.parse(decodeURIComponent(req.query.request as string))
+      } catch (err) {
+        throw new Error(err)
+      }
     }
   }
 
   if (req.query.request_format === 'search-query') { // search query and not Elastic DSL - we need to translate it
     const customFilters = await loadCustomFilters(config)
-    requestBody = await elasticsearch.buildQueryBodyFromSearchQuery({ config, queryChain: bodybuilder(), searchQuery: new SearchQuery(requestBody), customFilters })
+    requestBody = await elasticsearch.buildQueryBodyFromSearchQuery({ config: config as ElasticsearchQueryConfig, queryChain: bodybuilder(), searchQuery: new SearchQuery(requestBody), customFilters })
   }
-  if (req.query.response_format) responseFormat = req.query.response_format
+  if (req.query.response_format) responseFormat = req.query.response_format as string
 
-  const urlSegments = req.url.split('/');
+  const urlSegments = req.url.split('/')
 
   let indexName = ''
   let entityType = ''
   if (urlSegments.length < 2) { throw new Error('No index name given in the URL. Please do use following URL format: /api/catalog/<index_name>/<entity_type>_search') } else {
-    indexName = urlSegments[1];
+    indexName = urlSegments[1]
 
     if (urlSegments.length > 2) { entityType = urlSegments[2] }
 
-    if (config.elasticsearch.indices.indexOf(indexName) < 0) {
+    if (config.get<string[]>('elasticsearch.indices').indexOf(indexName) < 0) {
       throw new Error('Invalid / inaccessible index name given in the URL. Please do use following URL format: /api/catalog/<index_name>/_search')
     }
 
@@ -80,14 +86,17 @@ export default ({ config, db }) => async function (req, res, body) {
     }
   }
 
-  // pass the request to elasticsearch
-  const elasticBackendUrl = adjustBackendProxyUrl(req, indexName, entityType, config)
-  const userToken = requestBody.groupToken
-
   // Decode token and get group id
+  const userToken = requestBody.groupToken
   if (userToken && userToken.length > 10) {
-    const decodeToken = jwt.decode(userToken, config.authHashSecret ? config.authHashSecret : config.objHashSecret)
-    groupId = decodeToken.group_id || groupId
+    /**
+     * We need to use try catch so when we change the keys for encryption that not every request with a loggedin user
+     * fails with a 500 at this point.
+     **/
+    try {
+      const decodeToken = jwt.decode(userToken, config.get<string>('authHashSecret') ? config.get<string>('authHashSecret') : config.get<string>('objHashSecret'))
+      groupId = decodeToken.group_id || groupId
+    } catch (err) {}
   } else if (requestBody.groupId) {
     groupId = requestBody.groupId || groupId
   }
@@ -95,85 +104,100 @@ export default ({ config, db }) => async function (req, res, body) {
   delete requestBody.groupToken
   delete requestBody.groupId
 
-  let auth = null;
-
-  // Only pass auth if configured
-  if (config.elasticsearch.user || config.elasticsearch.password) {
-    auth = {
-      user: config.elasticsearch.user,
-      pass: config.elasticsearch.password
-    };
-  }
   const s = Date.now()
   const reqHash = sha3_224(`${JSON.stringify(requestBody)}${req.url}`)
   const dynamicRequestHandler = () => {
-    request({ // do the elasticsearch request
-      uri: elasticBackendUrl,
+    const reqQuery = Object.assign({}, req.query)
+    const reqQueryParams = adjustQueryParams(reqQuery, entityType, config)
+
+    const query = adjustQuery({
+      index: indexName,
       method: req.method,
-      body: requestBody,
-      json: true,
-      auth: auth
-    }, async (_err, _res, _resBody) => { // TODO: add caching layer to speed up SSR? How to invalidate products (checksum on the response BEFORE processing it)
-      if (_err || _resBody.error) {
-        Logger.error(_err || _resBody.error)
-        apiError(res, _err || _resBody.error);
-        return
-      }
-      try {
-        if (_resBody && _resBody.hits && _resBody.hits.hits) { // we're signing up all objects returned to the client to be able to validate them when (for example order)
-          const factory = new ProcessorFactory(config)
-          const tagsArray = []
-          if (config.server.useOutputCache && cache) {
-            const tagPrefix = entityType[0].toUpperCase() // first letter of entity name: P, T, A ...
-            tagsArray.push(entityType)
-            _resBody.hits.hits.map(item => {
-              if (item._source.id) { // has common identifier
-                tagsArray.push(`${tagPrefix}${item._source.id}`)
-              }
-            })
-            const cacheTags = tagsArray.join(' ')
-            res.setHeader('X-VS-Cache-Tags', cacheTags)
-          }
+      body: requestBody
+    }, entityType, config)
 
-          let resultProcessor = factory.getAdapter(entityType, indexName, req, res)
+    esClient(config)
+      .search(Object.assign(query, reqQueryParams))
+      .then(async response => {
+        let { body: _resBody } = response
 
-          if (!resultProcessor) { resultProcessor = factory.getAdapter('default', indexName, req, res) } // get the default processor
-
-          const productGroupId = entityType === 'product' ? groupId : undefined
-          const result = await resultProcessor.process(_resBody.hits.hits, productGroupId)
-          _resBody.hits.hits = result
-          _resBody = _outputFormatter(_resBody, responseFormat)
-          if (entityType === 'product' && _resBody.aggregations && config.entities.attribute.loadByAttributeMetadata) {
-            const attributeListParam = AttributeService.transformAggsToAttributeListParam(_resBody.aggregations)
-            // find attribute list
-            const attributeList = await AttributeService.list(attributeListParam, config, indexName)
-            _resBody.attribute_metadata = attributeList.map(AttributeService.transformToMetadata)
-          }
-          _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
-          res.json(_resBody);
-        } else { // no cache storage if no results from Elastic
-          res.json(_resBody);
+        if (_resBody.error) {
+          console.error('An error occured during catalog request:', _resBody.error)
+          apiError(res, _resBody.error)
+          return
         }
-      } catch (err) {
-        apiError(res, err);
-      }
-    });
+
+        try {
+          if (_resBody && _resBody.hits && _resBody.hits.hits) { // we're signing up all objects returned to the client to be able to validate them when (for example order)
+            const factory = new ProcessorFactory(config)
+            const tagsArray = []
+            const categoryTagsArray = []
+            if (config.get<boolean>('server.useOutputCache') && cache) {
+              const tagPrefix = entityType[0].toUpperCase() // first letter of entity name: P, T, A ...
+              tagsArray.push(entityType)
+              _resBody.hits.hits.map(item => {
+                if (item._source.id) { // has common identifier
+                  tagsArray.push(`${tagPrefix}${item._source.id}`)
+
+                  if (entityType === 'product' && item._source.category_ids !== undefined) {
+                    item._source.category_ids
+                      .filter(id => !categoryTagsArray.includes(`C${id}`))
+                      .forEach(id => categoryTagsArray.push(`C${id}`))
+                  }
+                }
+              })
+
+              if (categoryTagsArray.length > 0) {
+                tagsArray.push('category', ...categoryTagsArray)
+              }
+
+              const cacheTags = tagsArray.join(' ')
+              res.setHeader('X-VS-Cache-Tags', cacheTags)
+            }
+
+            let resultProcessor = factory.getAdapter(entityType, indexName, req, res)
+
+            if (!resultProcessor) { resultProcessor = factory.getAdapter('default', indexName, req, res) } // get the default processor
+
+            const productGroupId = entityType === 'product' ? groupId : undefined
+            const result = await resultProcessor.process(_resBody.hits.hits, productGroupId)
+            _resBody.hits.hits = result
+            if (entityType === 'product' && _resBody.aggregations && config.get<boolean>('entities.attribute.loadByAttributeMetadata')) {
+              const attributeListParam = AttributeService.transformAggsToAttributeListParam(_resBody.aggregations)
+              // find attribute list
+              const attributeList = await AttributeService.list(attributeListParam, config, indexName)
+              _resBody.attribute_metadata = attributeList.map(AttributeService.transformToMetadata)
+            }
+
+            _resBody = _outputFormatter(_resBody, responseFormat)
+
+            _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
+          }
+
+          res.json(_resBody)
+        } catch (err) {
+          apiError(res, err)
+        }
+      })
+      .catch(err => {
+        apiError(res, err)
+      })
   }
 
-  if (config.server.useOutputCache && cache) {
+  if (config.get<boolean>('server.useOutputCache') && cache) {
     cache.get(
       'api:' + reqHash
     ).then(output => {
       if (output !== null) {
         res.setHeader('X-VS-Cache', 'Hit')
         res.json(output)
-        Logger.info(`cache hit [${req.url}], cached request: ${Date.now() - s}ms`)
+        console.log(`cache hit [${req.url}], cached request: ${Date.now() - s}ms`)
       } else {
         res.setHeader('X-VS-Cache', 'Miss')
-        Logger.info(`cache miss [${req.url}], request: ${Date.now() - s}ms`)
+        console.log(`cache miss [${req.url}], request: ${Date.now() - s}ms`)
         dynamicRequestHandler()
       }
-    }).catch(err => Logger.error(err))
+    }).catch(err => console.error(err))
   } else {
     dynamicRequestHandler()
   }

--- a/packages/default-catalog/graphql/elasticsearch/attribute/resolver.ts
+++ b/packages/default-catalog/graphql/elasticsearch/attribute/resolver.ts
@@ -2,7 +2,7 @@ import config from 'config';
 import client from '../client';
 import { buildQuery } from '../queryBuilder';
 import { getIndexName } from '../mapping'
-import { adjustQuery, getResponseObject } from '@storefront-api/lib/elastic'
+import { adjustQuery, getHits } from '@storefront-api/lib/elastic'
 
 async function listAttributes ({ attributes = null, filter = null, context, rootValue, _sourceIncludes, _sourceExcludes }) {
   const query = buildQuery({ filter: filter || attributes, pageSize: 150, type: 'attribute' });
@@ -14,7 +14,7 @@ async function listAttributes ({ attributes = null, filter = null, context, root
     _source_excludes: _sourceExcludes
   }
 
-  const response = getResponseObject(await client.search(adjustQuery(esQuery, 'attribute', config)));
+  const response = getHits(await client.search(adjustQuery(esQuery, 'attribute', config)))
 
   response.items = []
   response.total_count = response.hits.total

--- a/packages/default-catalog/graphql/elasticsearch/category/service.ts
+++ b/packages/default-catalog/graphql/elasticsearch/category/service.ts
@@ -2,14 +2,14 @@ import config from 'config';
 import client from '../client';
 import { buildQuery } from '../queryBuilder'
 import { getIndexName } from '../mapping'
-import { adjustQuery, getResponseObject } from '@storefront-api/lib/elastic'
+import { adjustQuery, getHits } from '@storefront-api/lib/elastic'
 import { aggregationsToAttributes } from '../attribute/aggregations'
 
 export async function list ({ search, filter, currentPage, pageSize = 200, sort, context, rootValue = null, _sourceIncludes, _sourceExcludes = null }) {
   const query = buildQuery({ search, filter, currentPage, pageSize, sort, type: 'category' });
 
   const esIndex = getIndexName(context.req.url)
-  let response = getResponseObject(await client.search(adjustQuery({
+  let response = getHits(await client.search(adjustQuery({
     index: esIndex,
     body: query,
     _source_excludes: _sourceExcludes,

--- a/packages/default-catalog/graphql/elasticsearch/client.ts
+++ b/packages/default-catalog/graphql/elasticsearch/client.ts
@@ -1,4 +1,4 @@
 import config from 'config';
-import es from '@storefront-api/lib/elastic'
+import * as es from '@storefront-api/lib/elastic'
 
 export default es.getClient(config)

--- a/packages/default-catalog/graphql/elasticsearch/cms/resolver.ts
+++ b/packages/default-catalog/graphql/elasticsearch/cms/resolver.ts
@@ -2,12 +2,12 @@ import config from 'config';
 import client from '../client';
 import { buildQuery } from '../queryBuilder';
 import { getIndexName } from '../mapping'
-import { adjustQuery, getResponseObject } from '@storefront-api/lib/elastic'
+import { adjustQuery, getHits } from '@storefront-api/lib/elastic'
 
 async function list ({ filter, currentPage, pageSize = 200, context, _source_include, type }) {
   const query = buildQuery({ filter, currentPage, pageSize, type });
 
-  const response = getResponseObject(await client.search(adjustQuery({
+  const response = getHits(await client.search(adjustQuery({
     index: getIndexName(context.req.url),
     body: query,
     _source_include

--- a/packages/default-catalog/graphql/elasticsearch/product/service.ts
+++ b/packages/default-catalog/graphql/elasticsearch/product/service.ts
@@ -3,7 +3,7 @@ import client from '../client';
 import { buildQuery } from '../queryBuilder';
 import esResultsProcessor from './processor'
 import { getIndexName } from '../mapping'
-import { adjustQuery, getResponseObject } from '@storefront-api/lib/elastic'
+import { adjustQuery, getHits } from '@storefront-api/lib/elastic'
 import { aggregationsToAttributes } from '../attribute/aggregations'
 
 export async function list ({ filter, sort = null, currentPage = null, pageSize, search = null, context, rootValue, _sourceIncludes = null, _sourceExcludes = null }) {
@@ -25,7 +25,7 @@ export async function list ({ filter, sort = null, currentPage = null, pageSize,
 
   const esIndex = getIndexName(context.req.url)
 
-  let response = getResponseObject(await client.search(adjustQuery({
+  let response = getHits(await client.search(adjustQuery({
     index: esIndex,
     type: 'product',
     body: query,

--- a/packages/default-catalog/graphql/elasticsearch/review/resolver.ts
+++ b/packages/default-catalog/graphql/elasticsearch/review/resolver.ts
@@ -2,14 +2,14 @@ import config from 'config';
 import client from '../client';
 import { buildQuery } from '../queryBuilder';
 import { getIndexName } from '../mapping'
-import { adjustQuery, getResponseObject } from '@storefront-api/lib/elastic'
+import { adjustQuery, getHits } from '@storefront-api/lib/elastic'
 import { aggregationsToAttributes } from '../attribute/aggregations'
 
 export async function list ({ search, filter, currentPage, pageSize = 200, sort, context, rootValue, _sourceIncludes, _sourceExcludes }) {
   const query = buildQuery({ search, filter, currentPage, pageSize, sort, type: 'review' });
 
   const esIndex = getIndexName(context.req.url)
-  let response = getResponseObject(await client.search(adjustQuery({
+  let response = getHits(await client.search(adjustQuery({
     index: esIndex,
     body: query,
     _source_includes: _sourceIncludes,

--- a/packages/default-catalog/graphql/elasticsearch/taxrule/resolver.ts
+++ b/packages/default-catalog/graphql/elasticsearch/taxrule/resolver.ts
@@ -2,12 +2,12 @@ import config from 'config';
 import client from '../client';
 import { buildQuery } from '../queryBuilder';
 import { getIndexName } from '../mapping'
-import { adjustQuery, getResponseObject } from '@storefront-api/lib/elastic'
+import { adjustQuery, getHits } from '@storefront-api/lib/elastic'
 
 async function taxrule ({ filter, context, rootValue }) {
   const query = buildQuery({ filter, pageSize: 150, type: 'taxrule' });
 
-  const response = getResponseObject(await client.search(adjustQuery({
+  const response = getHits(await client.search(adjustQuery({
     index: getIndexName(context.req.url),
     body: query
   }, 'taxrule', config)))

--- a/packages/default-catalog/helper/loadCustomFilters.ts
+++ b/packages/default-catalog/helper/loadCustomFilters.ts
@@ -1,12 +1,14 @@
 import path from 'path'
+import { IConfig } from 'config'
+import { FilterInterface } from 'storefront-query-builder'
 
-export default async function loadModuleCustomFilters (config: Record<string, any>, type = 'catalog'): Promise<any> {
-  const filters: any = {}
-  const filterPromises: Promise<any>[] = []
+export default async function loadModuleCustomFilters (config: IConfig, type = 'catalog'): Promise<Record<string, FilterInterface>> {
+  const filters: Record<string, FilterInterface> = {}
+  const filterPromises: Promise<void>[] = []
 
-  for (const mod of config.modules.defaultCatalog.registeredExtensions) {
-    if (Object.prototype.hasOwnProperty.call(config.extensions, mod) && Object.prototype.hasOwnProperty.call(config.extensions[mod], type + 'Filter') && Array.isArray(config.extensions[mod][type + 'Filter'])) {
-      const moduleFilter = config.extensions[mod][type + 'Filter']
+  for (const mod of config.get<string[]>('modules.defaultCatalog.registeredExtensions')) {
+    if (config.has(`extensions.${mod}.${type}Filter`) && Array.isArray(config.get<string[]>(`extensions.${mod}.${type}Filter`))) {
+      const moduleFilter = config.get<string[]>(`extensions.${mod}.${type}Filter`)
       const dirPath = [__dirname, '../api/extensions/' + mod + '/filter/', type]
       for (const filterName of moduleFilter) {
         const filePath = path.resolve(...dirPath, filterName)

--- a/packages/default-catalog/helper/loadCustomFilters.ts
+++ b/packages/default-catalog/helper/loadCustomFilters.ts
@@ -5,7 +5,7 @@ export default async function loadModuleCustomFilters (config: Record<string, an
   const filterPromises: Promise<any>[] = []
 
   for (const mod of config.modules.defaultCatalog.registeredExtensions) {
-    if (Object.prototype.hasOwnProperty.call(config.extensions, mod) && Object.prototype.hasOwnProperty.call(config.extensions, type + 'Filter') && Array.isArray(config.extensions[mod][type + 'Filter'])) {
+    if (Object.prototype.hasOwnProperty.call(config.extensions, mod) && Object.prototype.hasOwnProperty.call(config.extensions[mod], type + 'Filter') && Array.isArray(config.extensions[mod][type + 'Filter'])) {
       const moduleFilter = config.extensions[mod][type + 'Filter']
       const dirPath = [__dirname, '../api/extensions/' + mod + '/filter/', type]
       for (const filterName of moduleFilter) {
@@ -23,5 +23,5 @@ export default async function loadModuleCustomFilters (config: Record<string, an
     }
   }
 
-  return Promise.all(filterPromises).then((e) => filters)
+  return Promise.all(filterPromises).then(() => filters)
 }

--- a/packages/default-vsf/api/map.ts
+++ b/packages/default-vsf/api/map.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import semver from 'semver'
+import { ExtensionAPIFunctionParameter } from '@storefront-api/lib/module'
 import { apiStatus, getCurrentStoreView, getCurrentStoreCode } from '@storefront-api/lib/util';
 import ProcessorFactory from '@storefront-api/default-catalog/processor/factory';
 import { getClient as getElasticClient } from '@storefront-api/lib/elastic'
@@ -70,7 +71,7 @@ const checkFieldValueEquality = ({ config, result, value }) => {
   return Boolean(isEqualValue)
 }
 
-const map = ({ config }) => {
+const map = ({ config, db }: ExtensionAPIFunctionParameter): Router => {
   const router = Router()
   router.post('/', async (req, res) => {
     const { url, excludeFields, includeFields } = req.body

--- a/packages/default-vsf/api/url.ts
+++ b/packages/default-vsf/api/url.ts
@@ -1,10 +1,11 @@
-import { Router } from 'express';
-import createMapRoute from './map';
+import { Router } from 'express'
+import { ExtensionAPIFunctionParameter } from '@storefront-api/lib/module'
+import createMapRoute from './map'
 
-export default ({ config, db }) => {
+export default ({ config, db }: ExtensionAPIFunctionParameter): Router => {
   const router = Router()
 
-  router.use('/map', createMapRoute({ config }))
+  router.use('/map', createMapRoute({ config, db }))
 
   return router
 }

--- a/packages/lib/elastic.ts
+++ b/packages/lib/elastic.ts
@@ -1,35 +1,129 @@
-import { Client, RequestParams, ClientOptions } from '@elastic/elasticsearch'
-import semver from 'semver';
 import _ from 'lodash'
 import path from 'path'
 import fs from 'fs'
 import jsonFile from 'jsonfile'
-import { IConfig } from 'config';
+import querystring from 'querystring'
+import { Client } from '@elastic/elasticsearch'
+import { IConfig } from 'config'
 import Logger from '@storefront-api/lib/logger'
 
-function _updateQueryStringParameter (uri: string, key: string|number, value: string|number) {
-  const regExp = new RegExp('([?&])' + key + '=.*?(&|#|$)', 'i');
-  if (uri.match(regExp)) {
-    if (value) {
-      return uri.replace(regExp, '$1' + key + '=' + value + '$2');
-    } else {
-      return uri.replace(regExp, '$1' + '$2');
-    }
+function adjustIndexName (indexName: string, entityType: string, config: IConfig): string {
+  if (parseInt(config.get<string>('elasticsearch.apiVersion')) < 6) {
+    return indexName
   } else {
-    let hash = '';
-    if (uri.indexOf('#') !== -1) {
-      hash = uri.replace(/.*#/, '#');
-      uri = uri.replace(/#.*/, '');
-    }
-    const separator = uri.indexOf('?') !== -1 ? '&' : '?';
-    return uri + separator + key + '=' + value + hash;
+    return `${indexName}_${entityType}`
   }
 }
 
+function decorateBackendUrl (entityType, url, req, config) {
+  const {
+    useRequestFilter,
+    requestParamsBlacklist,
+    overwriteRequestSourceParams,
+    apiVersion
+  } = config.elasticsearch
+
+  if (useRequestFilter && typeof config.entities[entityType] === 'object') {
+    const urlParts = url.split('?')
+    const { includeFields, excludeFields } = config.entities[entityType]
+
+    const filteredParams = Object.keys(req.query)
+      .filter(key => !requestParamsBlacklist.includes(key))
+      .reduce((object, key) => {
+        object[key] = req.query[key]
+        return object
+      }, {})
+
+    let _source_include = includeFields || []
+    let _source_exclude = excludeFields || []
+
+    if (!overwriteRequestSourceParams) {
+      const requestSourceInclude = req.query._source_include || []
+      const requestSourceExclude = req.query._source_exclude || []
+      _source_include = [...includeFields, ...requestSourceInclude]
+      _source_exclude = [...excludeFields, ...requestSourceExclude]
+    }
+
+    const isEs6AndUp = (parseInt(apiVersion) >= 6)
+    const _sourceIncludeKey = isEs6AndUp ? '_source_includes' : '_source_include'
+    const _sourceExcludeKey = isEs6AndUp ? '_source_excludes' : '_source_exclude'
+
+    const urlParams = {
+      ...filteredParams,
+      [_sourceIncludeKey]: _source_include,
+      [_sourceExcludeKey]: _source_exclude
+    }
+    url = `${urlParts[0]}?${querystring.stringify(urlParams)}`
+  }
+
+  return url
+}
+
+function adjustQueryParams (query, entityType, config) {
+  delete query.request
+  delete query.request_format
+  delete query.response_format
+
+  const {
+    apiVersion,
+    useRequestFilter,
+    overwriteRequestSourceParams,
+    requestParamsBlacklist,
+    cacheRequest
+  } = config.elasticsearch
+
+  if (useRequestFilter && !overwriteRequestSourceParams && typeof config.entities[entityType] === 'object') {
+    const { includeFields, excludeFields } = config.entities[entityType]
+    const requestSourceInclude = query._source_include ? query._source_include.split(',') : []
+    const requestSourceExclude = query._source_exclude ? query._source_exclude.split(',') : []
+    query._source_include = [...includeFields, ...requestSourceInclude]
+    query._source_exclude = [...excludeFields, ...requestSourceExclude]
+  }
+
+  if (parseInt(apiVersion) >= 6) { // legacy for ES 5
+    query._source_includes = query._source_include
+    query._source_excludes = query._source_exclude
+    delete query._source_exclude
+    delete query._source_include
+    if (cacheRequest) {
+      query.request_cache = !!cacheRequest
+    }
+  }
+
+  if (useRequestFilter && typeof config.entities[entityType] === 'object') {
+    query = Object.keys(query)
+      .filter(key => !requestParamsBlacklist.includes(key))
+      .reduce((object, key) => {
+        object[key] = query[key]
+        return object
+      }, {})
+  }
+
+  return query
+}
+
+function adjustBackendProxyUrl (req, indexName, entityType, config) {
+  let url
+  const queryString = require('query-string');
+  const parsedQuery = adjustQueryParams(queryString.parseUrl(req.url).query, entityType, config)
+
+  if (parseInt(config.elasticsearch.apiVersion) < 6) { // legacy for ES 5
+    url = config.elasticsearch.host + ':' + config.elasticsearch.port + '/' + indexName + '/' + entityType + '/_search?' + queryString.stringify(parsedQuery)
+  } else {
+    url = config.elasticsearch.host + ':' + config.elasticsearch.port + '/' + adjustIndexName(indexName, entityType, config) + '/_search?' + queryString.stringify(parsedQuery)
+  }
+
+  if (!url.startsWith('http')) {
+    url = config.elasticsearch.protocol + '://' + url
+  }
+
+  return decorateBackendUrl(entityType, url, req, config)
+}
+
 /**
- * similar to `adjustBackendProxyUrl`, builds multi-entity query url
+ * Similar to `adjustBackendProxyUrl`, builds multi-entity query url
  */
-export function buildMultiEntityUrl ({ config, includeFields = [], excludeFields = [] }: { config: IConfig, includeFields: string[], excludeFields: string[] }) {
+function buildMultiEntityUrl ({ config, includeFields = [], excludeFields = [] }: { config: IConfig, includeFields: string[], excludeFields: string[] }) {
   let url = `${config.get('elasticsearch.host')}:${config.get('elasticsearch.port')}/_search?_source_includes=${includeFields.join(',')}&_source_excludes=${excludeFields.join(',')}`
   if (!url.startsWith('http')) {
     url = config.get('elasticsearch.protocol') + '://' + url
@@ -37,150 +131,147 @@ export function buildMultiEntityUrl ({ config, includeFields = [], excludeFields
   return url
 }
 
-export function adjustIndexName (indexName: string|string[], entityType: string, config: IConfig) {
-  const realIndexName = Array.isArray(indexName) ? indexName[0] : indexName;
-
-  if (semver.major(semver.coerce(config.get<string>('elasticsearch.apiVersion'))) < 6) {
-    return realIndexName
-  } else {
-    return `${realIndexName}_${entityType}`
-  }
-}
-
-export function adjustBackendProxyUrl (req, indexName: string, entityType: string, config: IConfig) {
-  let url
-  const queryString = require('query-string');
-  const parsedQuery = queryString.parseUrl(req.url).query
-
-  if (semver.major(semver.coerce(config.get<string>('elasticsearch.apiVersion'))) < 6) { // legacy for ES 5
-    delete parsedQuery.request
-    delete parsedQuery.request_format
-    delete parsedQuery.response_format
-    url = config.get<string>('elasticsearch.host') + ':' + config.get<string>('elasticsearch.port') + '/' + indexName + '/' + entityType + '/_search?' + queryString.stringify(parsedQuery)
-  } else {
-    parsedQuery._source_includes = parsedQuery._source_include
-    parsedQuery._source_excludes = parsedQuery._source_exclude
-    delete parsedQuery._source_exclude
-    delete parsedQuery._source_include
-    delete parsedQuery.request
-    delete parsedQuery.request_format
-    delete parsedQuery.response_format
-    if (config.get<boolean>('elasticsearch.cacheRequest')) {
-      parsedQuery.request_cache = !!config.get<boolean>('elasticsearch.cacheRequest')
-    }
-    url = config.get<string>('elasticsearch.host') + ':' + config.get<number>('elasticsearch.port') + '/' + adjustIndexName(indexName, entityType, config) + '/_search?' + queryString.stringify(parsedQuery)
-  }
-  if (!url.startsWith('http')) {
-    url = config.get<string>('elasticsearch.protocol') + '://' + url
-  }
-  return url
-}
-
-export function adjustQuery (esQuery: RequestParams.Search, entityType: string, config: IConfig) {
-  if (semver.major(semver.coerce(config.get<string>('elasticsearch.apiVersion'))) < 6) {
+function adjustQuery (esQuery, entityType, config) {
+  if (parseInt(config.elasticsearch.apiVersion) < 6) {
     esQuery.type = entityType
   } else {
     delete esQuery.type
   }
+
   esQuery.index = adjustIndexName(esQuery.index, entityType, config)
   return esQuery
 }
 
-export function getResponseObject (result) {
-  if (result.body) { // differences between ES5 andd ES7
-    return result.body
-  } else {
-    return result
-  }
-}
-
-export function getHits (result) {
-  if (result.body) { // differences between ES5 andd ES7
+function getHits (result) {
+  if (result.body) { // differences between ES5 and ES7
     return result.body.hits.hits
   } else {
     return result.hits.hits
   }
 }
 
+/**
+ * Support for ES7+ where the `total` now is an object
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html
+ */
+const getTotals = body => typeof body.hits.total === 'object' ? body.hits.total.value : body.hits.total
+
 let esClient = null
-export function getClient (config: IConfig): Client {
-  const { host, port, protocol, requestTimeout } = config.get('elasticsearch')
-  const node = `${protocol}://${host}:${port}`
+function getClient (config) {
+  if (esClient) {
+    return esClient
+  }
+
+  const { host, port, protocol, requestTimeout, pingTimeout } = config.elasticsearch
+
+  const nodes = []
+  const hosts = typeof host === 'string' ? host.split(',') : host
+
+  hosts.forEach(host => {
+    const node = `${protocol}://${host}:${port}`
+    nodes.push(node)
+  })
 
   let auth
-
-  if (config.has('elasticsearch.user')) {
-    const { user, password } = config.get('elasticsearch')
+  if (config.elasticsearch.user) {
+    const { user, password } = config.elasticsearch
     auth = { username: user, password }
   }
 
-  if (!esClient) {
-    esClient = new Client({ node, auth, requestTimeout })
-  }
+  esClient = new Client({ nodes, auth, requestTimeout, pingTimeout })
 
   return esClient
 }
 
-export async function putAlias (db: Client, originalName: string, aliasName: string) {
-  try {
-    await db.indices.deleteAlias({
-      index: aliasName,
-      name: originalName
+function putAlias (db, originalName, aliasName, next) {
+  const step2 = () => {
+    db.indices.putAlias({ index: originalName, name: aliasName }).then(() => {
+      console.log('Index alias created')
+    }).then(next).catch(err => {
+      console.log(err.message)
+      next()
     })
-    Logger.info('Public index alias deleted')
-  } catch (err) {
-    Logger.info('Public index alias does not exists', err.message)
-  } finally {
-    try {
-      await db.indices.putAlias({ index: originalName, name: aliasName })
-      Logger.info('Index alias created')
-    } catch (err) {
-      Logger.info(err.message)
-    }
   }
+  return db.indices.deleteAlias({
+    index: aliasName,
+    name: originalName
+  }).then(() => {
+    console.log('Public index alias deleted')
+    step2()
+  }).catch((err) => {
+    console.log('Public index alias does not exists', err.message)
+    step2()
+  })
 }
 
-export function search (db: Client, query: RequestParams.Search) {
+function search (db, query) {
   return db.search(query)
 }
 
-export async function deleteIndex (db: Client, indexName: string) {
-  try {
-    await db.indices.delete({ index: indexName })
-    Logger.info('Public index deleted')
-  } catch (err) {
-    Logger.info('Public index does not exists', err.message)
-    try {
-      await db.indices.deleteAlias({
-        index: '*',
-        name: indexName
-      })
-      Logger.info('Public index alias deleted')
-    } catch (err) {
-      Logger.info('Public index alias does not exists', err.message)
+function deleteIndex (db, indexName, next) {
+  db.indices.delete({
+    index: indexName
+  }).then(() => {
+    next()
+  }).catch(err => {
+    if (err) {
+      console.error(err)
     }
-  }
-}
-
-export async function reIndex (db: Client, fromIndexName: string, toIndexName: string) {
-  try {
-    db.reindex({
-      wait_for_completion: true,
-      body: {
-        source: {
-          index: fromIndexName
-        },
-        dest: {
-          index: toIndexName
-        }
-      }
+    return db.indices.deleteAlias({
+      index: '*',
+      name: indexName
+    }).then(() => {
+      console.log('Public index alias deleted')
+      next()
+    }).catch((err) => {
+      console.log('Public index alias does not exists', err.message)
+      next()
     })
-  } catch (err) {
-    Logger.info('Reindex failed with message', err.message)
-  }
+  })
 }
 
-export async function createIndex<T = any> (db: Client, indexName: string, indexSchema: T) {
+function reIndex (db, fromIndexName, toIndexName, next) {
+  db.reindex({
+    wait_for_completion: true,
+    waitForCompletion: true,
+    body: {
+      source: {
+        index: fromIndexName
+      },
+      dest: {
+        index: toIndexName
+      }
+    }
+  }).then(() => {
+    next()
+  }).catch(err => {
+    next(err)
+  })
+}
+
+/**
+ * Load the schema definition for particular entity type
+ * @param {String} rootPath
+ * @param {String} entityType
+ * @param {String} apiVersion
+ */
+function loadSchema (rootPath: string, entityType: string, apiVersion = '7.1') {
+  const rootSchemaPath = path.join(rootPath, 'elastic.schema.' + entityType + '.json')
+  if (!fs.existsSync(rootSchemaPath)) {
+    return null
+  }
+  let schemaContent = jsonFile.readFileSync(rootSchemaPath)
+  let elasticSchema = parseInt(apiVersion) < 6 ? schemaContent : Object.assign({}, { mappings: schemaContent });
+  const extensionsPath = path.join(__dirname, 'elastic.schema.' + entityType + '.extension.json');
+  if (fs.existsSync(extensionsPath)) {
+    schemaContent = jsonFile.readFileSync(extensionsPath)
+    const elasticSchemaExtensions = parseInt(apiVersion) < 6 ? schemaContent : Object.assign({}, { mappings: schemaContent });
+    elasticSchema = _.merge(elasticSchema, elasticSchemaExtensions) // user extensions
+  }
+  return elasticSchema
+}
+
+async function createIndex<T = any> (db: Client, indexName: string, indexSchema: T): Promise<void> {
   try {
     await db.indices.deleteAlias({
       index: '*',
@@ -205,39 +296,18 @@ export async function createIndex<T = any> (db: Client, indexName: string, index
   }
 }
 
-/**
- * Load the schema definition for particular entity type
- * @param {String} rootPath
- * @param {String} entityType
- * @param {String} apiVersion
- */
-export function loadSchema (rootPath: string, entityType: string, apiVersion = '7.1') {
-  const rootSchemaPath = path.join(rootPath, 'elastic.schema.' + entityType + '.json')
-  if (!fs.existsSync(rootSchemaPath)) {
-    return null
-  }
-  let schemaContent = jsonFile.readFileSync(rootSchemaPath)
-  let elasticSchema = parseInt(apiVersion) < 6 ? schemaContent : Object.assign({}, { mappings: schemaContent });
-  const extensionsPath = path.join(__dirname, 'elastic.schema.' + entityType + '.extension.json');
-  if (fs.existsSync(extensionsPath)) {
-    schemaContent = jsonFile.readFileSync(extensionsPath)
-    const elasticSchemaExtensions = parseInt(apiVersion) < 6 ? schemaContent : Object.assign({}, { mappings: schemaContent });
-    elasticSchema = _.merge(elasticSchema, elasticSchemaExtensions) // user extensions
-  }
-  return elasticSchema
-}
-
-export default {
+export {
   putAlias,
   createIndex,
   deleteIndex,
   reIndex,
   search,
   adjustQuery,
+  adjustQueryParams,
   adjustBackendProxyUrl,
   getClient,
   getHits,
-  getResponseObject,
+  getTotals,
   adjustIndexName,
   loadSchema,
   buildMultiEntityUrl

--- a/packages/platform-magento1/tax.ts
+++ b/packages/platform-magento1/tax.ts
@@ -2,7 +2,7 @@ import AbstractTaxProxy from '@storefront-api/platform-abstract/tax'
 import { calculateProductTax, checkIfTaxWithUserGroupIsActive, getUserGroupIdToUse } from '@storefront-api/lib/taxcalc'
 import TierHelper from '@storefront-api/lib/helpers/priceTiers'
 import bodybuilder from 'bodybuilder'
-import es from '@storefront-api/lib/elastic'
+import * as es from '@storefront-api/lib/elastic'
 
 class TaxProxy extends AbstractTaxProxy {
   private readonly _deprecatedPriceFieldsSupport: any

--- a/packages/platform-magento2/tax.ts
+++ b/packages/platform-magento2/tax.ts
@@ -1,7 +1,7 @@
 import AbstractTaxProxy from '@storefront-api/platform-abstract/tax'
 import { calculateProductTax, checkIfTaxWithUserGroupIsActive, getUserGroupIdToUse } from '@storefront-api/lib/taxcalc';
 import TierHelper from '@storefront-api/lib/helpers/priceTiers'
-import es from '@storefront-api/lib/elastic'
+import * as es from '@storefront-api/lib/elastic'
 import bodybuilder from 'bodybuilder'
 
 class TaxProxy extends AbstractTaxProxy {

--- a/src/modules/template-module/graphql/hello/resolver.ts
+++ b/src/modules/template-module/graphql/hello/resolver.ts
@@ -1,6 +1,6 @@
 import { StoreFrontResloverContext } from '@storefront-api/lib/module/types';
 import { IResolvers } from 'apollo-server-express';
-import es from '@storefront-api/lib/elastic'
+import * as es from '@storefront-api/lib/elastic'
 import bodybuilder from 'bodybuilder'
 
 const resolver: IResolvers<any, StoreFrontResloverContext> = {
@@ -15,7 +15,7 @@ const resolver: IResolvers<any, StoreFrontResloverContext> = {
         type: 'product',
         body: bodybuilder().filter('terms', 'visibility', [2, 3, 4]).andFilter('term', 'status', 1).andFilter('terms', 'sku', sku).build()
       }, 'product', config)
-      const response = es.getResponseObject(await client.search(esQuery)).hits.hits.map(el => { return el._source })
+      const response = es.getHits(await client.search(esQuery)).hits.hits.map(el => { return el._source })
       if (response.length > 0) return response[0]; else return null
     }
   }


### PR DESCRIPTION
### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->

According to the changes in `vue-storefront-api`I've made to fully support ES7 and use the build in ES client class in [this PR](vuestorefront/vue-storefront-api/pull/512) adapted to `storefront-api`.

These are some proposals to have a more stable support for the current ES version and more flexibility:

* Remove type attribute from attribute/service/list method as it is already resolved by the adjustQuery depending on its version and will drop an ES exception if it is left in the search query
* Remove _updateQueryStringParameter method as it is unused as it is nowhere called
* Add getTotals method to elastic lib as from ES7 the totals return value is an object
* Add pingTimeout option and possibility for multiple ES hosts to elastic lib
* Use elasticsearch client library in catalog endpoint to make ES settings more consistent
* Localize catalog-attributes that stored in cache
* Prevent exception in `redis-tag-cache` when tags are empty
* Bugfix for attribute aggregations with nested buckets

These changes are pretty similar to the ones I've proposed for the `vue-storefront-api`: vuestorefront/vue-storefront-api/pull/512.

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
