### PR TITLE
Fix util missing cipher iv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bugfix for encrypting/decrypting user data via `packages/lib/util` - @oleksii-lisovyi (#110)
 - Bugfix for loading correct resolvers files in production build - @cewald (#104)
 
 ### Changed / Improved

--- a/packages/lib/util.ts
+++ b/packages/lib/util.ts
@@ -1,6 +1,5 @@
 import config from 'config'
-import crypto from 'crypto'
-import { Cipher, Decipher } from 'crypto'
+import { Cipher, Decipher, createCipheriv, createDecipheriv, randomBytes} from 'crypto'
 
 const algorithm = 'aes-256-ctr'
 
@@ -106,8 +105,8 @@ export function apiError (res, error: Record<any, any>): string|Record<any, any>
  * @return {String}
  */
 export function encryptToken (textToken: string, secret: string): string {
-  const iv: Buffer = crypto.randomBytes(16),
-    cipher: Cipher = crypto.createCipheriv(algorithm, secret, iv);
+  const iv: Buffer = randomBytes(16),
+    cipher: Cipher = createCipheriv(algorithm, secret, iv);
 
   let crypted: string = cipher.update(textToken, 'utf8', 'hex');
   crypted += cipher.final('hex');
@@ -131,7 +130,7 @@ export function decryptToken (textToken: string, secret: string): string {
   const dataBuffer: Buffer = Buffer.from(textToken, 'hex'),
     payload: { [key: string]: string; } = JSON.parse(dataBuffer.toString('ascii')),
     ivBuffer: Buffer = Buffer.from(payload.iv, 'hex'),
-    decipher: Decipher = crypto.createDecipheriv(algorithm, secret, ivBuffer);
+    decipher: Decipher = createDecipheriv(algorithm, secret, ivBuffer);
 
   let decrypted: string = decipher.update(payload.data, 'hex', 'utf8');
   decrypted += decipher.final('utf8');


### PR DESCRIPTION
### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->

-

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

This pull request fixes issue with getting error while encrypting/decrypting any text via `@storefront-api/lib/util` `enryptToken()` or `decryptToken()` functions:

> Error: Missing IV for cipher aes-256-ctr

In quick way the issue could be reproduced with the following sample code:
```javascript

const util = require('@storefront-api/lib/util');

util.encryptToken('text', 'my_secret');

```

Also it's occurred when you're calling endpoints `/user/login`, `/user/refresh`.

_Note:_
There is another implementation of the issue that was already proposed before - https://github.com/vuestorefront/storefront-api/pull/103, but due to implementation issues I found and because I only want to fix the issue itself, the current PR was created in favour.

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI, please provide before/after screenshots -->

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
